### PR TITLE
feat(CCollapseBtn): remove inheritBtnClass config option, closes #155

### DIFF
--- a/packages/chusho/lib/components/CCollapse/CCollapseBtn.ts
+++ b/packages/chusho/lib/components/CCollapse/CCollapseBtn.ts
@@ -33,7 +33,7 @@ export default defineComponent({
         ...this.$props,
         active: isActive,
       }),
-      bare: this.config?.inheritBtnClass === false,
+      bare: true,
       active: isActive,
     };
 

--- a/packages/chusho/lib/types/index.ts
+++ b/packages/chusho/lib/types/index.ts
@@ -38,9 +38,7 @@ interface ComponentsOptions {
   collapse?: ComponentCommonOptions & {
     transition?: BaseTransitionProps;
   };
-  collapseBtn?: ComponentCommonOptions & {
-    inheritBtnClass: boolean;
-  };
+  collapseBtn?: ComponentCommonOptions;
   collapseContent?: ComponentCommonOptions & {
     transition?: BaseTransitionProps;
   };

--- a/packages/chusho/src/chusho.config.js
+++ b/packages/chusho/src/chusho.config.js
@@ -43,7 +43,6 @@ export default {
     },
 
     collapseBtn: {
-      inheritBtnClass: false,
       class({ active }) {
         return [
           'py-2 px-4 border-2 border-gray-400 rounded',

--- a/packages/docs/guide/components/collapse.md
+++ b/packages/docs/guide/components/collapse.md
@@ -49,15 +49,6 @@ class({ active }) {
 }
 ```
 
-### CCollapseBtn
-
-#### inheritBtnClass
-
-Since the CCollapseBtn is a CBtn in the background, it will inherits its `class` config option. To disable this behavior, set this option to `false`.
-
-- **type:** `Boolean`
-- **default:** `true`
-
 ### CCollapseContent
 
 #### transition


### PR DESCRIPTION
BREAKING CHANGE:

CCollapseBtn doesn’t inherit CBtn `class` config anymore.